### PR TITLE
Switch logging backend to logback and colorize the logging output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,11 +13,15 @@ assemblyJarName in assembly := "docile.jar"
 connectInput in run := true
 
 libraryDependencies ++= Seq(
-  "biz.enef"              %% "slogging"       % "0.6.0",
-  "com.lihaoyi"            % "ammonite"       % "1.0.3"    cross CrossVersion.full,
-  "com.thenewmotion.ocpp" %% "ocpp-j-api"     % "6.0.3",
-  "org.rogach"            %% "scallop"        % "3.1.1",
-  "org.scala-lang"         % "scala-compiler" % "2.11.11",
-  "org.slf4j"              % "slf4j-nop"      % "1.7.25",
-  "org.specs2"            %% "specs2-core"    % "4.0.2"    % "test"
+  "com.lihaoyi"            % "ammonite"         % "1.0.3"    cross CrossVersion.full,
+  "com.thenewmotion.ocpp" %% "ocpp-j-api"       % "6.0.3",
+  "org.rogach"            %% "scallop"          % "3.1.1",
+  "org.scala-lang"         % "scala-compiler"   % "2.11.11",
+
+  "biz.enef"              %% "slogging"         % "0.6.1",
+  "biz.enef"              %% "slogging-slf4j"   % "0.6.1",
+  "org.slf4j"              % "slf4j-api"        % "1.7.25",
+  "ch.qos.logback"         % "logback-classic"  % "1.2.3",
+
+  "org.specs2"            %% "specs2-core"      % "4.0.2"    % "test"
 )

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%d %highlight(%-5level) %magenta(%-10logger{10}) [%green(%thread)]  - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/scala/chargepoint/docile/dsl/MessageLogging.scala
+++ b/src/main/scala/chargepoint/docile/dsl/MessageLogging.scala
@@ -1,0 +1,8 @@
+package chargepoint.docile.dsl
+
+import slogging.{Logger, LoggerFactory, StrictLogging}
+
+trait MessageLogging extends StrictLogging {
+  protected val incomingLogger: Logger = LoggerFactory.getLogger("| <<=")
+  protected val outgoingLogger: Logger = LoggerFactory.getLogger("| =>>")
+}

--- a/src/main/scala/chargepoint/docile/dsl/OpsLogging.scala
+++ b/src/main/scala/chargepoint/docile/dsl/OpsLogging.scala
@@ -1,0 +1,7 @@
+package chargepoint.docile.dsl
+
+import slogging.{Logger, LoggerFactory, StrictLogging}
+
+trait OpsLogging extends StrictLogging {
+  protected val opsLogger: Logger = LoggerFactory.getLogger("operation")
+}

--- a/src/main/scala/chargepoint/docile/test/InteractiveOcppTest.scala
+++ b/src/main/scala/chargepoint/docile/test/InteractiveOcppTest.scala
@@ -19,10 +19,12 @@ class InteractiveOcppTest extends OcppTest {
       """
         |import ops._
         |import promptCommands._
+        |import com.thenewmotion.ocpp.messages._
+        |
         |import scala.language.postfixOps
         |import scala.concurrent.duration._
         |import java.time._
-        |import com.thenewmotion.ocpp.messages._
+        |
       """.stripMargin
 
     ammonite.Main(predefCode = imports).run(

--- a/src/main/scala/chargepoint/docile/test/Runner.scala
+++ b/src/main/scala/chargepoint/docile/test/Runner.scala
@@ -132,7 +132,6 @@ class Runner(testCases: Seq[TestCase]) extends StrictLogging {
     }
 
     logger.debug(s"Test ${c.name} run; disconnecting...")
-
     logger.debug(s"Disconnected OCPP connection for ${runnerCfg.chargePointId}/${c.name}")
 
     c.name -> res
@@ -162,15 +161,20 @@ object Runner extends StrictLogging {
     val toolbox = currentMirror.mkToolBox()
 
     val preamble = s"""
+                   |import com.thenewmotion.ocpp.messages._
+                   |
                    |import scala.language.postfixOps
                    |import scala.concurrent.duration._
                    |import java.time._
-                   |import com.thenewmotion.ocpp.messages._
+                   |import slogging.{LoggerFactory, StrictLogging}
                    |
                    |new chargepoint.docile.dsl.OcppTest
                    |  with chargepoint.docile.dsl.CoreOps
                    |  with chargepoint.docile.dsl.expectations.Ops
-                   |  with chargepoint.docile.dsl.shortsend.Ops {
+                   |  with chargepoint.docile.dsl.shortsend.Ops
+                   |  with StrictLogging {
+                   |
+                   |  override val logger = LoggerFactory.getLogger("script")
                    |
                    |  def run() {
                    """.stripMargin


### PR DESCRIPTION
Thi PR is to improve logging: make formatted and add some colours to log levels, loggers and thread name in log message. 

The logging backend is switched to logback and uses it's formatting capabilities. 