### PR TITLE
Implement expectAllIgnoringUnmatched DSL command.

### DIFF
--- a/src/main/scala/chargepoint/docile/dsl/AwaitTimeout.scala
+++ b/src/main/scala/chargepoint/docile/dsl/AwaitTimeout.scala
@@ -1,0 +1,5 @@
+package chargepoint.docile.dsl
+
+import scala.concurrent.duration.Duration
+
+case class AwaitTimeout(timeout: Duration)

--- a/src/main/scala/chargepoint/docile/dsl/CoreOps.scala
+++ b/src/main/scala/chargepoint/docile/dsl/CoreOps.scala
@@ -50,11 +50,14 @@ trait CoreOps extends OpsLogging with MessageLogging {
     }
   }
 
-  def awaitIncoming(num: Int): Seq[IncomingMessage] = {
+  def awaitIncoming(num: Int)(implicit awaitTimeout: AwaitTimeout): Seq[IncomingMessage] = {
+
+    val AwaitTimeout(timeout) = awaitTimeout
     def getMsgs = connectionData.receivedMsgManager.dequeue(num)
-    Try(Await.result(getMsgs, 45.seconds)) match {
+
+    Try(Await.result(getMsgs, timeout)) match {
       case Success(msgs)                => msgs
-      case Failure(e: TimeoutException) => fail(s"Expected message not received after 45 seconds")
+      case Failure(e: TimeoutException) => fail(s"Expected message not received after $timeout")
       case Failure(e)                   => error(e)
     }
   }

--- a/src/main/scala/chargepoint/docile/dsl/shortsend/Ops.scala
+++ b/src/main/scala/chargepoint/docile/dsl/shortsend/Ops.scala
@@ -10,10 +10,14 @@ trait Ops {
 
   self: CoreOps with expectations.Ops =>
 
-  def authorize(idTag: String = "01020304"): AuthorizeRes =
+  def authorize(idTag: String = "01020304")(
+    implicit awaitTimeout: AwaitTimeout
+  ): AuthorizeRes =
     sendSync(AuthorizeReq(idTag))
 
-  def heartbeat(): HeartbeatRes =
+  def heartbeat()(
+    implicit awaitTimeout: AwaitTimeout
+  ): HeartbeatRes =
     sendSync(HeartbeatReq)
 
   def bootNotification(
@@ -26,6 +30,8 @@ trait Ops {
     imsi: Option[String] = None,
     meterType: Option[String] = None,
     meterSerialNumber: Option[String] = None
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): BootNotificationRes =
     sendSync(BootNotificationReq(
       chargePointVendor,
@@ -43,6 +49,8 @@ trait Ops {
     vendorId: String = "NewMotion",
     messageId: Option[String] = Some("MogrifyEspolusion"),
     data: Option[String] = None
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): CentralSystemDataTransferRes =
     sendSync(CentralSystemDataTransferReq(
       vendorId,
@@ -52,6 +60,8 @@ trait Ops {
 
   def diagnosticsStatusNotification(
     status: DiagnosticsStatus = DiagnosticsStatus.Idle
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): DiagnosticsStatusNotificationRes.type =
     sendSync(DiagnosticsStatusNotificationReq(
       status
@@ -59,6 +69,8 @@ trait Ops {
 
   def firmwareStatusNotification(
     status: FirmwareStatus = FirmwareStatus.Idle
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): FirmwareStatusNotificationRes.type =
     sendSync(FirmwareStatusNotificationReq(
       status
@@ -83,6 +95,8 @@ trait Ops {
         )
       )
     )
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): MeterValuesRes.type =
     sendSync(MeterValuesReq(
       scope,
@@ -96,6 +110,8 @@ trait Ops {
     timestamp: ZonedDateTime = ZonedDateTime.now,
     meterStart: Int = 0,
     reservationId: Option[Int] = None
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): StartTransactionRes =
     sendSync(StartTransactionReq(
       connector,
@@ -110,6 +126,8 @@ trait Ops {
     status: ChargePointStatus = ChargePointStatus.Available(),
     timestamp: Option[ZonedDateTime] = Some(ZonedDateTime.now()),
     vendorId: Option[String] = None
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): StatusNotificationRes.type =
     sendSync(StatusNotificationReq(
       scope,
@@ -125,6 +143,8 @@ trait Ops {
     meterStop: Int = 16000,
     reason: StopReason = StopReason.Local,
     meters: List[meter.Meter] = List()
+  )(
+    implicit awaitTimeout: AwaitTimeout
   ): StopTransactionRes =
     sendSync(StopTransactionReq(
       transactionId,
@@ -135,8 +155,13 @@ trait Ops {
       meters
     ))
 
-  def sendSync[REQ <: CentralSystemReq, RES <: CentralSystemRes : ClassTag](req: REQ)
-                                                                           (implicit reqRes: CentralSystemReqRes[REQ, RES]): RES = {
+  def sendSync[REQ <: CentralSystemReq, RES <: CentralSystemRes : ClassTag](
+    req: REQ
+  )(
+    implicit
+    reqRes: CentralSystemReqRes[REQ, RES],
+    awaitTimeout: AwaitTimeout
+  ): RES = {
     self.send(req)
     self.expectIncoming(matching { case res: RES => res })
   }

--- a/src/main/scala/chargepoint/docile/test/InteractiveOcppTest.scala
+++ b/src/main/scala/chargepoint/docile/test/InteractiveOcppTest.scala
@@ -25,6 +25,10 @@ class InteractiveOcppTest extends OcppTest {
         |import scala.concurrent.duration._
         |import java.time._
         |
+        |import chargepoint.docile.dsl.AwaitTimeout
+        |
+        |implicit val awaitTimeout: AwaitTimeout = AwaitTimeout(45.seconds)
+        |
       """.stripMargin
 
     ammonite.Main(predefCode = imports).run(

--- a/src/main/scala/chargepoint/docile/test/Runner.scala
+++ b/src/main/scala/chargepoint/docile/test/Runner.scala
@@ -173,6 +173,8 @@ object Runner extends StrictLogging {
                    |import java.time._
                    |import slogging.{LoggerFactory, StrictLogging}
                    |
+                   |import chargepoint.docile.dsl.AwaitTimeout
+                   |
                    |new chargepoint.docile.dsl.OcppTest
                    |  with chargepoint.docile.dsl.CoreOps
                    |  with chargepoint.docile.dsl.expectations.Ops
@@ -181,19 +183,23 @@ object Runner extends StrictLogging {
                    |
                    |  override val logger = LoggerFactory.getLogger("script")
                    |
+                   |  implicit val awaitTimeout: AwaitTimeout = AwaitTimeout(45.seconds)
+                   |
                    |  def run() {
                    """.stripMargin
     val appendix = ";\n  }\n}"
 
     val fileContents = scala.io.Source.fromFile(file).getLines.mkString("\n")
 
+    logger.info(s"Parsing and compiling script '$f'")
+
     val fileAst = toolbox.parse(preamble + fileContents + appendix)
 
-    logger.debug(s"Parsed $f")
+    logger.info(s"Parsed '$f'")
 
     val compiledCode = toolbox.compile(fileAst)
 
-    logger.debug(s"Compiled $f")
+    logger.info(s"Compiled '$f'")
 
     TestCase(testName, () => compiledCode().asInstanceOf[OcppTest])
   }

--- a/src/test/scala/chargepoint/docile/dsl/expectations/OpsSpec.scala
+++ b/src/test/scala/chargepoint/docile/dsl/expectations/OpsSpec.scala
@@ -1,0 +1,78 @@
+package chargepoint.docile.dsl.expectations
+
+import chargepoint.docile.dsl.{AwaitTimeout, CoreOps, OcppConnectionData}
+import com.thenewmotion.ocpp.json.api.OcppError
+import com.thenewmotion.ocpp.messages._
+import org.specs2.mutable.Specification
+
+import scala.collection.JavaConversions._
+
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration._
+
+class OpsSpec extends Specification {
+
+  "Ops" should {
+    "await for messages ignoring not matched" in {
+      val mock = new MutableOpsMock()
+
+      import mock.ops._
+
+      implicit val awaitTimeout: AwaitTimeout = AwaitTimeout(5.seconds)
+
+      mock send GetConfigurationReq(keys = List())
+      mock send ClearCacheReq
+
+      val result: Seq[ChargePointReq] =
+
+      expectAllIgnoringUnmatched(
+        clearCacheReq respondingWith ClearCacheRes(accepted = true)
+      )
+
+      result must_=== Seq(ClearCacheReq)
+      mock.responses.size must_=== 1
+      mock.responses.head must_=== ClearCacheRes(accepted = true)
+    }
+  }
+
+  class MutableOpsMock {
+    import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, TimeUnit}
+
+    private val requestsQueue: BlockingQueue[IncomingMessage] = new ArrayBlockingQueue[IncomingMessage](1000)
+    private val responsesQueue: BlockingQueue[ChargePointRes] = new ArrayBlockingQueue[ChargePointRes](1000)
+
+    def responses: Iterable[ChargePointRes] = responsesQueue.toIterable
+
+    private def enqueueResponse(x: ChargePointRes): Unit = {
+      responsesQueue.put(x)
+    }
+
+    def send(req: ChargePointReq): Unit = {
+      requestsQueue.put(IncomingRequest(req, enqueueResponse))
+    }
+
+    def send(res: CentralSystemRes): Unit = {
+      requestsQueue.put(IncomingResponse(res))
+    }
+
+    def sendError(err: OcppError): Unit = {
+      requestsQueue.put(IncomingError(err))
+    }
+
+    val ops: Ops = new Ops with CoreOps {
+      override protected def connectionData: OcppConnectionData = {
+        throw new AssertionError("This method should not be called")
+      }
+
+      override def awaitIncoming(num: Int)(implicit awaitTimeout: AwaitTimeout): Seq[IncomingMessage] = {
+        for (_ <- 0 until num) yield {
+          val value = requestsQueue.poll(awaitTimeout.timeout.toMillis, TimeUnit.MILLISECONDS)
+          if (value == null) {
+            throw new TimeoutException("Failed to receive the message on time")
+          }
+          value
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `expectAllIgnoringUnmatched` directive allows to describe match patterns for number of commands but this pattern should not be exhaustive: messages that did not match will be logged and ignored.