### PR TITLE
Rename 'wait' operation to 'sleep'

### DIFF
--- a/examples/sleep.scala
+++ b/examples/sleep.scala
@@ -1,0 +1,1 @@
+sleep(10.seconds)

--- a/examples/wait.scala
+++ b/examples/wait.scala
@@ -1,1 +1,0 @@
-wait(10.seconds)

--- a/src/main/scala/chargepoint/docile/dsl/CoreOps.scala
+++ b/src/main/scala/chargepoint/docile/dsl/CoreOps.scala
@@ -79,7 +79,11 @@ trait CoreOps extends OpsLogging with MessageLogging {
 
   def error(throwable: Throwable): Nothing = throw ExecutionError(throwable)
 
-  def wait(duration: FiniteDuration): Unit = Thread.sleep(duration.toMillis)
+  def sleep(duration: FiniteDuration): Unit = {
+
+    opsLogger.info(s"Sleeping for $duration")
+    Thread.sleep(duration.toMillis)
+  }
 
   def prompt(cue: String): String = {
     println(s"$cue: ")


### PR DESCRIPTION
The `wait` method in `CoreOps` clashes with Java's `Object::wait()`. It works well if you're running emulator in script mode. In interactive mode ammonite resolves `wait` as `Object::wait(long)` instead of `CoreOps::wait(FiniteDuration)`.

This PR renames `wait` method to `sleep`