### PR TITLE
set the await timeout for incoming messages to 45s

### DIFF
--- a/aws-lambda/src/main/scala/chargepoint/docile/Lambda.scala
+++ b/aws-lambda/src/main/scala/chargepoint/docile/Lambda.scala
@@ -57,7 +57,7 @@ object Lambda extends App {
       ocppVersion = Version.withName(cpVersion).getOrElse(Version.V15),
       authKey = cpAuthKey,
       repeat = RunOnce,
-      defaultAwaitTimeout = AwaitTimeoutInMillis(45 * 60 * 1000),
+      defaultAwaitTimeout = AwaitTimeoutInMillis(45 * 1000),
       sslContext = SSLContext.getDefault
     )
 


### PR DESCRIPTION
It's 45 minutes right now, which seems excessive